### PR TITLE
[Refact & Feat] MiniGame 종료 시 판정 구현 및 버그 수정

### DIFF
--- a/src/main/java/kutaverse/game/websocket/minigame/GameRoom.java
+++ b/src/main/java/kutaverse/game/websocket/minigame/GameRoom.java
@@ -3,8 +3,10 @@ package kutaverse.game.websocket.minigame;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kutaverse.game.minigame.dto.MiniGameRequest;
+import kutaverse.game.minigame.service.MiniGameService;
 import kutaverse.game.websocket.minigame.dto.GameUpdateDTO;
 import lombok.Getter;
+import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.socket.WebSocketSession;
 import reactor.core.publisher.Mono;
 
@@ -19,15 +21,18 @@ import java.util.concurrent.ConcurrentHashMap;
 * 해당 방에는 player들을 저장(해당 유저의 아이디, 접속한 websocket session)
 * */
 @Getter
+@Component
 public class GameRoom {
     private final String roomId;
 
     private final Map<String, WebSocketSession> players = new ConcurrentHashMap<>();
     private final Map<String, Integer> playerScores = new ConcurrentHashMap<>();
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final MiniGameService miniGameService;
 
-    public GameRoom(String roomId) {
+    public GameRoom(String roomId, MiniGameService miniGameService) {
         this.roomId = roomId;
+        this.miniGameService = miniGameService;
     }
 
     /**
@@ -145,5 +150,7 @@ public class GameRoom {
     private void saveGameData(GameUpdateDTO gameUpdateDTO) {
         // 게임 데이터를 저장하는 로직을 여기에 추가합니다.
         // 예를 들어, 데이터베이스에 저장하거나 파일에 기록하는 등의 작업을 수행합니다.
+
+
     }
 }

--- a/src/main/java/kutaverse/game/websocket/minigame/GameRoom.java
+++ b/src/main/java/kutaverse/game/websocket/minigame/GameRoom.java
@@ -3,33 +3,48 @@ package kutaverse.game.websocket.minigame;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kutaverse.game.minigame.dto.MiniGameRequest;
+import kutaverse.game.websocket.minigame.dto.GameUpdateDTO;
 import lombok.Getter;
 import org.springframework.web.reactive.socket.WebSocketSession;
 import reactor.core.publisher.Mono;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 
 
+/*
+* 게임 방을 관리
+* 해당 방에는 player들을 저장(해당 유저의 아이디, 접속한 websocket session)
+* */
 @Getter
 public class GameRoom {
     private final String roomId;
 
     private final Map<String, WebSocketSession> players = new ConcurrentHashMap<>();
+    private final Map<String, Integer> playerScores = new ConcurrentHashMap<>();
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     public GameRoom(String roomId) {
         this.roomId = roomId;
     }
 
+    /**
+     * 게임 방에 플레이어를 추가
+     *
+     * @param userId           플레이어의 ID
+     * @param webSocketSession 플레이어의 WebSocket 세션
+     */
     public void addPlayer(String userId, WebSocketSession webSocketSession){
         players.put(userId,webSocketSession);
+        playerScores.put(userId,0);
     }
 
 
     public void removePlayer(String userId){
         players.remove(userId);
+        playerScores.remove(userId);
     }
 
     // 이건 나중에 필요한 값들을 보내는 용도
@@ -49,7 +64,11 @@ public class GameRoom {
                 });
     }
 
-    // 상대방이 나간 처리
+    /**
+     * 특정 플레이어가 게임 방을 떠났을 때 다른 모든 플레이어에게 알림
+     *
+     * @param userId 게임 방을 떠난 플레이어의 ID
+     */
     public void handlePlayerLeft(String userId){
         players.entrySet().stream()
                 .filter(entry -> !entry.getKey().equals(userId))
@@ -57,5 +76,74 @@ public class GameRoom {
                     WebSocketSession session = entry.getValue();
                     session.send(Mono.just(session.textMessage("상대방이 나갔습니다."))).subscribe();
                 });
+    }
+
+    /**
+     * 특정 플레이어의 점수를 업데이트
+     *
+     * @param userId 플레이어의 ID
+     * @param score  업데이트할 점수
+     */
+    public void updatePlayerScore(String userId, int score) {
+        playerScores.put(userId, score);
+    }
+
+
+    /**
+     * 특정 플레이어의 현재 점수를 반환
+     *
+     * @param userId 플레이어의 ID
+     * @return 플레이어의 현재 점수
+     */
+    public int getPlayerScore(String userId) {
+        return playerScores.getOrDefault(userId, 0);
+    }
+
+
+    /**
+     * 게임이 끝났음을 각 유저에게 알리고, 해당 게임의 데이터를 저장.
+     *
+     * @param miniGameRequest 저장할 게임 데이터
+     */
+    public void endGameAndNotifyPlayers(MiniGameRequest miniGameRequest) throws JsonProcessingException {
+        // 어떤 형식으로 데이터를 보낼 것인가?
+        // 유저1, 유저2, 점수1, 점수2, 누구 승
+
+        GameUpdateDTO gameUpdateDTO = new GameUpdateDTO();
+
+        Map.Entry<String, WebSocketSession> firstEntry = players.entrySet().iterator().next();
+        gameUpdateDTO.setPlayer1Id(firstEntry.getKey());
+        gameUpdateDTO.setPlayer1Score(getPlayerScore(firstEntry.getKey()));
+
+        Map.Entry<String, WebSocketSession> secondEntry = players.entrySet().iterator().next();
+        gameUpdateDTO.setPlayer2Id(secondEntry.getKey());
+        gameUpdateDTO.setPlayer2Score(getPlayerScore(secondEntry.getKey()));
+
+        String winnerId = miniGameRequest.getUserId().equals(firstEntry.getKey()) ? secondEntry.getKey() : firstEntry.getKey();
+        gameUpdateDTO.setWinnerId(winnerId);
+
+        gameUpdateDTO.setRoomId(miniGameRequest.getRoomId());
+
+        String gameDataJson = objectMapper.writeValueAsString(gameUpdateDTO);
+
+        // 각 유저에게 게임 종료 알림을 보낸다.
+        players.values().forEach(session -> {
+            session.send(Mono.just(session.textMessage("게임이 종료되었습니다. " + gameDataJson))).subscribe();
+        });
+
+        // 게임 데이터를 저장합니다.
+        saveGameData(gameUpdateDTO);
+    }
+
+
+
+    /**
+     * 게임 데이터를 저장
+     *
+     * @param gameUpdateDTO 저장할 게임 데이터
+     */
+    private void saveGameData(GameUpdateDTO gameUpdateDTO) {
+        // 게임 데이터를 저장하는 로직을 여기에 추가합니다.
+        // 예를 들어, 데이터베이스에 저장하거나 파일에 기록하는 등의 작업을 수행합니다.
     }
 }

--- a/src/main/java/kutaverse/game/websocket/minigame/GameRoom.java
+++ b/src/main/java/kutaverse/game/websocket/minigame/GameRoom.java
@@ -4,14 +4,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kutaverse.game.minigame.dto.MiniGameRequest;
 import kutaverse.game.minigame.service.MiniGameService;
-import kutaverse.game.websocket.minigame.dto.GameUpdateDTO;
+import kutaverse.game.websocket.minigame.dto.GameResultDTO;
 import lombok.Getter;
-import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.socket.WebSocketSession;
 import reactor.core.publisher.Mono;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 
@@ -21,7 +19,6 @@ import java.util.concurrent.ConcurrentHashMap;
 * 해당 방에는 player들을 저장(해당 유저의 아이디, 접속한 websocket session)
 * */
 @Getter
-@Component
 public class GameRoom {
     private final String roomId;
 
@@ -114,22 +111,22 @@ public class GameRoom {
         // 어떤 형식으로 데이터를 보낼 것인가?
         // 유저1, 유저2, 점수1, 점수2, 누구 승
 
-        GameUpdateDTO gameUpdateDTO = new GameUpdateDTO();
+        GameResultDTO gameResultDTO = new GameResultDTO();
 
         Map.Entry<String, WebSocketSession> firstEntry = players.entrySet().iterator().next();
-        gameUpdateDTO.setPlayer1Id(firstEntry.getKey());
-        gameUpdateDTO.setPlayer1Score(getPlayerScore(firstEntry.getKey()));
+        gameResultDTO.setPlayer1Id(firstEntry.getKey());
+        gameResultDTO.setPlayer1Score(getPlayerScore(firstEntry.getKey()));
 
         Map.Entry<String, WebSocketSession> secondEntry = players.entrySet().iterator().next();
-        gameUpdateDTO.setPlayer2Id(secondEntry.getKey());
-        gameUpdateDTO.setPlayer2Score(getPlayerScore(secondEntry.getKey()));
+        gameResultDTO.setPlayer2Id(secondEntry.getKey());
+        gameResultDTO.setPlayer2Score(getPlayerScore(secondEntry.getKey()));
 
         String winnerId = miniGameRequest.getUserId().equals(firstEntry.getKey()) ? secondEntry.getKey() : firstEntry.getKey();
-        gameUpdateDTO.setWinnerId(winnerId);
+        gameResultDTO.setWinnerId(winnerId);
 
-        gameUpdateDTO.setRoomId(miniGameRequest.getRoomId());
+        gameResultDTO.setRoomId(miniGameRequest.getRoomId());
 
-        String gameDataJson = objectMapper.writeValueAsString(gameUpdateDTO);
+        String gameDataJson = objectMapper.writeValueAsString(gameResultDTO);
 
         // 각 유저에게 게임 종료 알림을 보낸다.
         players.values().forEach(session -> {
@@ -137,7 +134,7 @@ public class GameRoom {
         });
 
         // 게임 데이터를 저장합니다.
-        saveGameData(gameUpdateDTO);
+        saveGameData(gameResultDTO);
     }
 
 
@@ -145,12 +142,11 @@ public class GameRoom {
     /**
      * 게임 데이터를 저장
      *
-     * @param gameUpdateDTO 저장할 게임 데이터
+     * @param gameResultDTO 저장할 게임 데이터
      */
-    private void saveGameData(GameUpdateDTO gameUpdateDTO) {
-        // 게임 데이터를 저장하는 로직을 여기에 추가합니다.
-        // 예를 들어, 데이터베이스에 저장하거나 파일에 기록하는 등의 작업을 수행합니다.
-
+    private void saveGameData(GameResultDTO gameResultDTO) {
+        // 현재 서버 이슈로 잠시 해당 기능은 주석 처리 함
+        // miniGameService.createGameResult(gameResultDTO).subscribe();
 
     }
 }

--- a/src/main/java/kutaverse/game/websocket/minigame/GameRoomManager.java
+++ b/src/main/java/kutaverse/game/websocket/minigame/GameRoomManager.java
@@ -25,6 +25,16 @@ public class GameRoomManager {
         gameRooms.remove(roomId);
     }
 
+    public static void updateGameRoom(String roomId, MiniGameRequest miniGameRequest){
+        GameRoom gameRoom = gameRooms.get(roomId);
+        gameRoom.updatePlayerScore(miniGameRequest.getUserId(),miniGameRequest.getScore());
+    }
+
+    public static void endGameAndNotifyRoom(MiniGameRequest miniGameRequest) throws JsonProcessingException {
+        GameRoom gameRoom = gameRooms.get(miniGameRequest.getRoomId());
+        gameRoom.endGameAndNotifyPlayers(miniGameRequest);
+    }
+
     public static void sendPlayerData(String roomId, String userId, MiniGameRequest data) throws JsonProcessingException {
         GameRoom gameRoom = getGameRoom(roomId);
         gameRoom.sendDataToOther(userId,data);

--- a/src/main/java/kutaverse/game/websocket/minigame/GameRoomManager.java
+++ b/src/main/java/kutaverse/game/websocket/minigame/GameRoomManager.java
@@ -5,7 +5,6 @@ import kutaverse.game.minigame.dto.MiniGameRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.socket.WebSocketSession;
-import reactor.core.publisher.Mono;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/main/java/kutaverse/game/websocket/minigame/MatchingMaker.java
+++ b/src/main/java/kutaverse/game/websocket/minigame/MatchingMaker.java
@@ -14,7 +14,6 @@ public class MatchingMaker {
 
     @Scheduled(fixedRate = 1000)
     public void matchPlayers(){
-        // log.info(String.valueOf(MatchingQueue.queueingSize()));
         while(MatchingQueue.queueingSize() >= 2){
             Map.Entry<String, WebSocketSession> player1 = MatchingQueue.getPlayer();
             Map.Entry<String, WebSocketSession> player2 = MatchingQueue.getPlayer();

--- a/src/main/java/kutaverse/game/websocket/minigame/MatchingMaker.java
+++ b/src/main/java/kutaverse/game/websocket/minigame/MatchingMaker.java
@@ -1,5 +1,7 @@
 package kutaverse.game.websocket.minigame;
 
+import kutaverse.game.minigame.service.MiniGameService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -8,9 +10,11 @@ import org.springframework.web.reactive.socket.WebSocketSession;
 import java.util.Map;
 
 @Component
+@RequiredArgsConstructor
 @Slf4j
 public class MatchingMaker {
 
+    private final MiniGameService miniGameService;
 
     @Scheduled(fixedRate = 1000)
     public void matchPlayers(){
@@ -36,7 +40,7 @@ public class MatchingMaker {
 
     private void createGameRoom( Map.Entry<String, WebSocketSession> player1,  Map.Entry<String, WebSocketSession> player2){
         String roomId = player1.getKey() + "-" + player2.getKey();
-        GameRoom gameRoom = new GameRoom(roomId);
+        GameRoom gameRoom = new GameRoom(roomId,miniGameService);
 
         gameRoom.addPlayer(player1.getKey(), player1.getValue());
         gameRoom.addPlayer(player2.getKey(), player2.getValue());

--- a/src/main/java/kutaverse/game/websocket/minigame/MatchingQueue.java
+++ b/src/main/java/kutaverse/game/websocket/minigame/MatchingQueue.java
@@ -1,7 +1,9 @@
 package kutaverse.game.websocket.minigame;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.socket.WebSocketSession;
+import reactor.core.publisher.Mono;
 
 import java.util.AbstractMap;
 import java.util.ArrayDeque;
@@ -12,6 +14,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 
 @Component
+@Slf4j
 public class MatchingQueue {
     private static final ArrayDeque<Map.Entry<String, WebSocketSession>> queueing = new ArrayDeque<>();
     private static final Map<String, WebSocketSession> sessionMap = new ConcurrentHashMap<>();
@@ -20,6 +23,7 @@ public class MatchingQueue {
         if(!sessionMap.containsKey(userId)) {
             queueing.offer(new AbstractMap.SimpleEntry<>(userId,webSocketSession));
             sessionMap.put(userId,webSocketSession);
+            webSocketSession.send(Mono.just(webSocketSession.textMessage("매칭 대기 중 입니다."))).subscribe();
         }
 
     }

--- a/src/main/java/kutaverse/game/websocket/minigame/MiniGameWebsocketHandler.java
+++ b/src/main/java/kutaverse/game/websocket/minigame/MiniGameWebsocketHandler.java
@@ -18,11 +18,9 @@ public class MiniGameWebsocketHandler implements org.springframework.web.reactiv
     public Mono<Void> handle(WebSocketSession session) {
         ObjectMapper objectMapper = new ObjectMapper();
         session.receive()
-                .doOnNext(message -> log.info("Received raw message: " + message.getPayloadAsText()))
                 .map(WebSocketMessage::getPayloadAsText)
                 .map(data -> {
                     try {
-                        log.info("test");
                         return objectMapper.readValue(data, MiniGameRequest.class);
                     } catch (Exception e) {
                         log.error("Error handling MiniGameRequest", e);
@@ -30,7 +28,6 @@ public class MiniGameWebsocketHandler implements org.springframework.web.reactiv
                     }
                 })
                 .subscribe(data -> {
-                    log.info("test2");
                     try {
                         handleMiniGameRequest((MiniGameRequest) data,session);
                     } catch (JsonProcessingException e) {

--- a/src/main/java/kutaverse/game/websocket/minigame/MiniGameWebsocketHandler.java
+++ b/src/main/java/kutaverse/game/websocket/minigame/MiniGameWebsocketHandler.java
@@ -2,7 +2,6 @@ package kutaverse.game.websocket.minigame;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.validation.constraints.NotNull;
 import kutaverse.game.minigame.dto.MiniGameRequest;
 import kutaverse.game.minigame.dto.MiniGameRequestType;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/kutaverse/game/websocket/minigame/MiniGameWebsocketHandler.java
+++ b/src/main/java/kutaverse/game/websocket/minigame/MiniGameWebsocketHandler.java
@@ -18,16 +18,19 @@ public class MiniGameWebsocketHandler implements org.springframework.web.reactiv
     public Mono<Void> handle(WebSocketSession session) {
         ObjectMapper objectMapper = new ObjectMapper();
         session.receive()
+                .doOnNext(message -> log.info("Received raw message: " + message.getPayloadAsText()))
                 .map(WebSocketMessage::getPayloadAsText)
                 .map(data -> {
                     try {
+                        log.info("test");
                         return objectMapper.readValue(data, MiniGameRequest.class);
                     } catch (Exception e) {
                         log.error("Error handling MiniGameRequest", e);
-                        return Mono.empty();
+                        return null;
                     }
                 })
                 .subscribe(data -> {
+                    log.info("test2");
                     try {
                         handleMiniGameRequest((MiniGameRequest) data,session);
                     } catch (JsonProcessingException e) {

--- a/src/main/java/kutaverse/game/websocket/minigame/MiniGameWebsocketHandler.java
+++ b/src/main/java/kutaverse/game/websocket/minigame/MiniGameWebsocketHandler.java
@@ -37,12 +37,26 @@ public class MiniGameWebsocketHandler implements org.springframework.web.reactiv
         return Mono.never();
     }
 
+    /*
+    * RequestType에 따라 다른 동작을 수행
+    * WAIT -> 현재 대기 상태, 매칭 큐에 들어간다.
+    * RUNNING -> 현재 게임 중인 상태, 자신의 상태(위치 값, 점수)를 상대방에게 보낸다.
+    * OVER -> 게임이 끝난 상태, 상대방에게도 게임 종료를 알리고 서로의 점수를 기록한다.
+    */
+
     private Mono<Void> handleMiniGameRequest(MiniGameRequest miniGameRequest,WebSocketSession session) throws JsonProcessingException {
         if (miniGameRequest.getMiniGameRequestType() == MiniGameRequestType.WAIT) {
             MatchingQueue.addPlayer(miniGameRequest.getUserId(), session);
         } else if (miniGameRequest.getMiniGameRequestType() == MiniGameRequestType.RUNNING) {
+            GameRoomManager.updateGameRoom(miniGameRequest.getRoomId(), miniGameRequest);
             GameRoomManager.sendPlayerData(miniGameRequest.getRoomId(), miniGameRequest.getUserId(), miniGameRequest);
         } else {
+            GameRoomManager.updateGameRoom(miniGameRequest.getRoomId(), miniGameRequest);
+
+            // 게임 승패 판정 -> 게임 룸 클래스에 함수를 추가?
+            GameRoomManager.endGameAndNotifyRoom(miniGameRequest);
+
+            // 게임 룸 삭제
             GameRoomManager.removeGameRoom(miniGameRequest.getRoomId());
         }
         return Mono.never();

--- a/src/main/java/kutaverse/game/websocket/minigame/dto/GameResultDTO.java
+++ b/src/main/java/kutaverse/game/websocket/minigame/dto/GameResultDTO.java
@@ -2,12 +2,24 @@ package kutaverse.game.websocket.minigame.dto;
 
 import kutaverse.game.minigame.domain.GameResult;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
 public class GameResultDTO {
     private String player1Id;
 
     private String player2Id;
+
+    private int player1Score;
+
+    private int player2Score;
+
+    private String winnerId;
 
     private String roomId;
 
@@ -16,6 +28,9 @@ public class GameResultDTO {
                 .player1Id(player1Id)
                 .player2Id(player2Id)
                 .roomId(roomId)
+                .player1Score(player1Score)
+                .player2Score(player2Score)
+                .winnerId(winnerId)
                 .build();
     }
 }

--- a/src/main/java/kutaverse/game/websocket/minigame/dto/GameResultDTO.java
+++ b/src/main/java/kutaverse/game/websocket/minigame/dto/GameResultDTO.java
@@ -2,7 +2,6 @@ package kutaverse.game.websocket.minigame.dto;
 
 import kutaverse.game.minigame.domain.GameResult;
 import lombok.AllArgsConstructor;
-import org.springframework.data.relational.core.mapping.Column;
 
 @AllArgsConstructor
 public class GameResultDTO {

--- a/src/main/java/kutaverse/game/websocket/minigame/dto/GameUpdateDTO.java
+++ b/src/main/java/kutaverse/game/websocket/minigame/dto/GameUpdateDTO.java
@@ -4,10 +4,14 @@ package kutaverse.game.websocket.minigame.dto;
 import kutaverse.game.minigame.domain.GameResult;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
+@Setter
 public class GameUpdateDTO {
     private String player1Id;
 

--- a/src/main/java/kutaverse/game/websocket/minigame/dto/GameUpdateDTO.java
+++ b/src/main/java/kutaverse/game/websocket/minigame/dto/GameUpdateDTO.java
@@ -5,7 +5,6 @@ import kutaverse.game.minigame.domain.GameResult;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
 
 @AllArgsConstructor
 @Getter

--- a/src/test/java/kutaverse/game/minigame/integration/MiniGameWebSocketTest.java
+++ b/src/test/java/kutaverse/game/minigame/integration/MiniGameWebSocketTest.java
@@ -86,7 +86,7 @@ public class MiniGameWebSocketTest {
         WebSocketSession test2Session = createMockWebSocketSession("test2");
 
         String roomId = "1";
-        GameRoom gameRoom = new GameRoom(roomId);
+        GameRoom gameRoom = new GameRoom(roomId,null);
 
         gameRoom.addPlayer("test1", test1Session);
         gameRoom.addPlayer("test2", test2Session);

--- a/src/test/java/kutaverse/game/minigame/integration/MiniGameWebSocketTest.java
+++ b/src/test/java/kutaverse/game/minigame/integration/MiniGameWebSocketTest.java
@@ -1,0 +1,145 @@
+package kutaverse.game.minigame.integration;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kutaverse.game.minigame.dto.ActorInfo;
+import kutaverse.game.minigame.dto.MiniGameRequest;
+import kutaverse.game.minigame.dto.MiniGameRequestType;
+import kutaverse.game.websocket.map.util.JsonUtil;
+import kutaverse.game.websocket.minigame.GameRoom;
+import kutaverse.game.websocket.minigame.GameRoomManager;
+import kutaverse.game.websocket.minigame.MatchingQueue;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.WebSocketSession;
+import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
+import org.springframework.web.reactive.socket.client.WebSocketClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class MiniGameWebSocketTest {
+    @LocalServerPort
+    private String port;
+
+    @Test
+    @DisplayName("Status == WAIT 이면 매칭 큐에 잡힌다.")
+    public void testStatusWait() throws Exception {
+        int connectionTimeSecond=2;
+        WebSocketClient client = new ReactorNettyWebSocketClient();
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        ActorInfo actorInfo = new ActorInfo("",0,0);
+        MiniGameRequest request = new MiniGameRequest(MiniGameRequestType.WAIT,"","test1",0,0,actorInfo);
+
+        String jsonRequest = objectMapper.writeValueAsString(request);
+        Exception exception = assertThrows(IllegalStateException.class, () ->
+                client.execute(getUrl("/game"), session -> {
+                            WebSocketMessage message = session.textMessage(jsonRequest);
+
+                            return session.send(Mono.just(message))
+                                    .then(session.receive()
+                                            .doOnNext(data -> {
+                                                String serverResponse = data.getPayloadAsText();
+                                                System.out.println(serverResponse);
+
+                                                assertEquals("매칭 대기 중 입니다.", serverResponse);
+
+                                            })
+                                            .then()
+                                    )
+                                    .then();
+                        })
+                        .block(Duration.ofSeconds(connectionTimeSecond))
+        );
+
+        String expectedMessage = "Timeout on blocking read for 2";
+        String actualMessage = exception.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    @DisplayName("Status == RUNNING 이면 상대방에게 나의 정보값이 넘어간다.")
+    public void testStatusRunning() throws Exception {
+        int connectionTimeSecond=2;
+        WebSocketClient client = new ReactorNettyWebSocketClient();
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        // User Setting
+        ActorInfo actorInfo = new ActorInfo("1",0,0);
+        MiniGameRequest request = new MiniGameRequest(MiniGameRequestType.RUNNING,"1","test1",0,0,actorInfo);
+
+        // GameRoom Setting
+        WebSocketSession test1Session = createMockWebSocketSession("test1");
+        WebSocketSession test2Session = createMockWebSocketSession("test2");
+
+        String roomId = "1";
+        GameRoom gameRoom = new GameRoom(roomId);
+
+        gameRoom.addPlayer("test1", test1Session);
+        gameRoom.addPlayer("test2", test2Session);
+
+        GameRoomManager.addGameRoom(gameRoom);
+
+
+        String jsonRequest = objectMapper.writeValueAsString(request);
+        Exception exception = assertThrows(IllegalStateException.class, () ->
+                client.execute(getUrl("/game"), session -> {
+                            WebSocketMessage message = session.textMessage(jsonRequest);
+                            return session.send(Mono.just(message))
+                                    .then(session.receive()
+                                            .doOnNext(data -> {
+                                                String serverResponse = data.getPayloadAsText();
+                                                System.out.println("Received response: " + serverResponse);
+                                            })
+                                            .then()
+                                    );
+                        })
+                        .block(Duration.ofSeconds(connectionTimeSecond))
+        );
+
+        String expectedMessage = "Timeout on blocking read for 2";
+        String actualMessage = exception.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    // @DisplayName("Status == OVER 이면 종료 메시지가 넘어간다.")
+
+    private URI getUrl(String path) throws URISyntaxException {
+        return new URI("ws://localhost:" + port + path);
+    }
+
+    private WebSocketSession createMockWebSocketSession(String playerId) throws JsonProcessingException {
+        WebSocketSession mockSession = Mockito.mock(WebSocketSession.class);
+
+        Mockito.when(mockSession.getId()).thenReturn(playerId);
+
+        Mockito.when(mockSession.close()).thenReturn(Mono.empty());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        ActorInfo actorInfo = new ActorInfo("1",0,0);
+        MiniGameRequest request = new MiniGameRequest(MiniGameRequestType.RUNNING,"1","test1",0,0,actorInfo);
+        String dataJson = objectMapper.writeValueAsString(request);
+
+        WebSocketMessage mockMessage = Mockito.mock(WebSocketMessage.class);
+        Mockito.when(mockSession.send(Mockito.any())).thenReturn(Mono.just(mockMessage).then());
+
+        Mockito.when(mockSession.textMessage(Mockito.anyString())).thenReturn(mockMessage);
+
+
+        return mockSession;
+    }
+}
+


### PR DESCRIPTION
### ✏️ 작업 개요
미니게임 종료 시 판정과 결과 저장에 대한 기능 구현

### ⛳ 작업 분류
- [x] Status가 Over일 경우 핸들러 구현
- [ ] WebSocket Test 코드 작성(아직 Over시는 못함)
- [x] 불필요한 패킷, 함수 삭제 및 버그 수정

### 🔨 작업 상세 내용
  1. 미니게임과 관련된 버그 및 Over 시의 기능 구현

### 💡 생각해볼 문제
- 현재 GameRoom이나 GameRoomManager, Matching 등 다양한 함수들이 존재하고 얽혀있습니다. 테스트 코드를 작성할 때 보니 생각보다 꽤 얽혀 있어서 조금 더 나은 방향으로 클래스들을 구분하고 다시 만들어야하나 고민 중입니다.
