### PR TITLE
[CI/CD] 도커 컴포즈 설정 변경

### DIFF
--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: redis
     ports:
       - "6379:6379"
+
   mysql:
     image: mysql
     ports:
@@ -11,6 +12,9 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: 12345678
       TZ: Asia/Seoul
+    volumes:
+      - mysql-data:/var/lib/mysql
+
   springbootapp:
     image: ji0513ji/game-server:latest
 #    build:
@@ -23,3 +27,6 @@ services:
       - mysql
     environment:
       - SPRING_PROFILES_ACTIVE=prodDB
+
+volumes:
+  mysql-data:

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -23,4 +23,3 @@ services:
       - mysql
     environment:
       - SPRING_PROFILES_ACTIVE=prodDB
-


### PR DESCRIPTION
### ✏️ 작업 개요
도커 컴포즈 설정 변경

### ⛳ 작업 분류
- [x] 도커 컴포즈 mysql volume 추가

### 🔨 작업 상세 내용
  1. 도커 컴포즈 mysql volume 추가를 위해 하나의 볼륨을 만듭니다. 이 볼륨은 있으면 해당 볼륨을 가져와 mysql 저장 위치에 마운트 시킵니다. 최초에 해당 볼륨이 없다면 생성하여 해당 위치에 마운트 시킵니다.

### 💡 생각해볼 문제
- 현재 파일을 보면 redis, spring, mysql 모두 컨테이너와 도커 호스트 간에 포트 포워딩 설정을 해둔 것을 볼 수 있습니다. 모두 다 포트를 열어두는게 맞을지 의문이 듭니다. spring만 열어두고 다른 것들은 외부에서 해당 컨테이너(mysql, redis)로 원격 접속할 이유가 없다면 굳이 열어둘 필요가 없어 보입니다.

```Docker
docker exec -it [해당컨테이너] /bin/bash
```

위와 같은 방법으로 해당 컨테이너에 접속하여 확인이 가능합니다. 이렇게 제의하는 이유는 해당 컨테이너들은 외부로 열어둘 필요가 없고 내부 시스템에서만 동작하는 친구들이라 이렇게 제안해봅니다.
