### PR TITLE
채팅 기능 추가, 이동 db 변경

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -57,6 +57,7 @@ jobs:
         env:
           SPRING_R2DBC_URL: r2dbc:pool:mysql://localhost:3306/testdb
           SPRING_R2DBC_PASSWORD: testdb
+          MONGO_URL: ${{ secrets.MONGO_URL }}
         run: ./gradlew build
 
       # Gradle Test를 실행한다

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,8 @@ dependencies {
 
 	implementation "org.springframework.boot:spring-boot-starter-data-r2dbc"
 	implementation "com.github.jasync-sql:jasync-r2dbc-mysql:2.2.0"
-
+	//mongodb
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
 	//JUnit4 추가
 	/*testImplementation("org.junit.vintage:junit-vintage-engine") {
 		exclude group: "org.hamcrest", module: "hamcrest-core"

--- a/infra/sql/user.sql
+++ b/infra/sql/user.sql
@@ -1,5 +1,6 @@
 CREATE TABLE map_user (
-                      user_id VARCHAR(255) NOT NULL PRIMARY KEY,
+                      id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                      user_id VARCHAR(255) NOT NULL ,
                       position_x DOUBLE NOT NULL,
                       position_y DOUBLE NOT NULL,
                       position_z DOUBLE NOT NULL,

--- a/src/main/java/kutaverse/game/chat/domain/Chat.java
+++ b/src/main/java/kutaverse/game/chat/domain/Chat.java
@@ -1,0 +1,22 @@
+package kutaverse.game.chat.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.experimental.WithBy;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Document(collation = "chat")
+@AllArgsConstructor
+@Builder
+public class Chat {
+
+    @Id
+    private String id;
+    private String senderUserId;
+    private String content;
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/kutaverse/game/chat/repository/ChatRepository.java
+++ b/src/main/java/kutaverse/game/chat/repository/ChatRepository.java
@@ -1,0 +1,11 @@
+package kutaverse.game.chat.repository;
+
+import kutaverse.game.chat.domain.Chat;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRepository extends ReactiveMongoRepository<Chat,String> {
+}

--- a/src/main/java/kutaverse/game/chat/service/ChatService.java
+++ b/src/main/java/kutaverse/game/chat/service/ChatService.java
@@ -1,0 +1,26 @@
+package kutaverse.game.chat.service;
+
+import kutaverse.game.chat.domain.Chat;
+import kutaverse.game.chat.repository.ChatRepository;
+import kutaverse.game.websocket.chat.dto.request.ChatRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final ChatRepository chatRepository;
+
+    public Mono<Chat> save(ChatRequestDto chatRequestDto){
+        Chat chat=Chat.builder()
+                .senderUserId(chatRequestDto.getUserId())
+                .content(chatRequestDto.getContent())
+                .createdAt(LocalDateTime.now())
+                .build();
+        return chatRepository.save(chat);
+    }
+}

--- a/src/main/java/kutaverse/game/chat/service/ChatService.java
+++ b/src/main/java/kutaverse/game/chat/service/ChatService.java
@@ -21,6 +21,6 @@ public class ChatService {
                 .content(chatRequestDto.getContent())
                 .createdAt(LocalDateTime.now())
                 .build();
-        return chatRepository.save(chat);
+        return chatRepository.insert(chat);
     }
 }

--- a/src/main/java/kutaverse/game/map/domain/User.java
+++ b/src/main/java/kutaverse/game/map/domain/User.java
@@ -16,10 +16,12 @@ import java.util.Objects;
 
 @Getter
 @NoArgsConstructor
-@Table(name = "map_user")
+@Table(name = "user")
 public class User {
 
     @Id
+    private Long id;
+
     private String userId;
 
     private Double positionX;

--- a/src/main/java/kutaverse/game/map/domain/User.java
+++ b/src/main/java/kutaverse/game/map/domain/User.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 
 @Getter
 @NoArgsConstructor
-@Table(name = "user")
+@Table(name = "map_user")
 public class User {
 
     @Id

--- a/src/main/java/kutaverse/game/map/domain/User.java
+++ b/src/main/java/kutaverse/game/map/domain/User.java
@@ -89,4 +89,19 @@ public class User {
     public int hashCode() {
         return Objects.hash(getUserId(), getPositionX(), getPositionY(), getPositionZ(), getRotationPitch(), getRotationYaw(), getRotationRoll(), getStatus(), getVelocityX(), getVelocityY(), getVelocityZ());
     }
+
+    public void updateUser(User user){
+        this.userId = user.getUserId();
+        this.positionX = user.getPositionX();
+        this.positionY = user.getPositionY();
+        this.positionZ = user.getPositionZ();
+        this.rotationPitch = user.getRotationPitch();
+        this.rotationYaw = user.getRotationYaw();
+        this.rotationRoll = user.getRotationRoll();
+        this.status = user.getStatus();
+        this.velocityX = user.getVelocityX();
+        this.velocityY = user.getVelocityY();
+        this.velocityZ = getVelocityZ();
+        this.localDateTime = LocalDateTime.parse(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")), DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
 }

--- a/src/main/java/kutaverse/game/map/repository/MysqlUserRepository.java
+++ b/src/main/java/kutaverse/game/map/repository/MysqlUserRepository.java
@@ -19,13 +19,16 @@ public class MysqlUserRepository implements UserRepository {
 
     @Override
     public Mono<User> save(User user) {
-        return get(user.getUserId())
-                .flatMap(user1 -> update(user))
+        return getByUserId(user.getUserId())
+                .flatMap(existingUser -> {
+                    existingUser.updateUser(user);
+                    return update(existingUser);
+                })
                 .switchIfEmpty(r2dbcEntityTemplate.insert(user));
     }
 
     @Override
-    public Mono<User> get(String userId) {
+    public Mono<User> getByUserId(String userId) {
         return r2dbcEntityTemplate.select(Query.query(where("user_id").is(userId)), User.class)
                 .single()
                 .onErrorResume(e -> Mono.empty());

--- a/src/main/java/kutaverse/game/map/repository/UserRepository.java
+++ b/src/main/java/kutaverse/game/map/repository/UserRepository.java
@@ -1,14 +1,13 @@
 package kutaverse.game.map.repository;
 
 import kutaverse.game.map.domain.User;
-import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface UserRepository {
     Mono<User> save(User user);
 
-    Mono<User> get(String userId);
+    Mono<User> getByUserId(String userId);
 
     Flux<User> getAll();
 

--- a/src/main/java/kutaverse/game/websocket/WebsocketConfig.java
+++ b/src/main/java/kutaverse/game/websocket/WebsocketConfig.java
@@ -1,5 +1,8 @@
 package kutaverse.game.websocket;
 
+import kutaverse.game.chat.repository.ChatRepository;
+import kutaverse.game.chat.service.ChatService;
+import kutaverse.game.websocket.chat.ChatWebSocketHandler;
 import kutaverse.game.websocket.map.MapWebSocketHandler;
 import kutaverse.game.websocket.minigame.MiniGameWebsocketHandler;
 import org.springframework.context.annotation.Bean;
@@ -24,10 +27,20 @@ public class WebsocketConfig {
 	}
 
 	@Bean
-	public SimpleUrlHandlerMapping handlerMapping(MapWebSocketHandler mapWsh, MiniGameWebsocketHandler miniWsh) {
+	public ChatWebSocketHandler chatWebSocketHandler(ChatService chatService) {
+		return new ChatWebSocketHandler(chatService);
+	}
+	@Bean
+	public ChatService chatService(ChatRepository chatRepository) {
+		return new ChatService(chatRepository);
+	}
+
+	@Bean
+	public SimpleUrlHandlerMapping handlerMapping(MapWebSocketHandler mapWsh, MiniGameWebsocketHandler miniWsh, ChatWebSocketHandler chatWsh) {
 		return new SimpleUrlHandlerMapping(Map.of(
 				"/map", mapWsh,
-				"/game", miniWsh
+				"/game", miniWsh,
+				"/chat", chatWsh
 		), 1);
 	}
 

--- a/src/main/java/kutaverse/game/websocket/chat/ChatWebSocketHandler.java
+++ b/src/main/java/kutaverse/game/websocket/chat/ChatWebSocketHandler.java
@@ -1,0 +1,66 @@
+package kutaverse.game.websocket.chat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kutaverse.game.chat.service.ChatService;
+import kutaverse.game.websocket.chat.dto.request.ChatRequestDto;
+import kutaverse.game.websocket.chat.dto.response.ChatResponseDto;
+import kutaverse.game.websocket.map.dto.request.UserRequestDto;
+import kutaverse.game.websocket.map.handler.WebSocketHandlerMapping;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.WebSocketSession;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ChatWebSocketHandler implements WebSocketHandler {
+
+    private final Map<String, WebSocketSession> sessions = new ConcurrentHashMap<>();
+
+    private final ChatService chatService;
+    public ChatWebSocketHandler(ChatService chatService){
+        this.chatService=chatService;
+    }
+
+    @Override
+    public Mono<Void> handle(WebSocketSession session) {
+        sessions.put(session.getId(), session);
+        ObjectMapper objectMapper=new ObjectMapper();
+        session.receive()
+                .map(WebSocketMessage::getPayloadAsText)
+                .map(data-> {
+                    try {
+                        return objectMapper.readValue(data, ChatRequestDto.class);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .doOnNext(System.out::println)
+                .map(chatRequest -> {
+                    chatService.save(chatRequest).subscribe();
+                    ChatResponseDto response = new ChatResponseDto(chatRequest.getUserId(), chatRequest.getContent());
+                    try {
+                        return objectMapper.writeValueAsString(response);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .flatMap(data->{
+                    Flux.fromIterable(sessions.values())
+                            .flatMap(wsSession -> {
+                                if (!wsSession.getId().equals(session.getId())) {
+                                    return wsSession.send(Mono.just(wsSession.textMessage(data)));
+                                } else {
+                                    return Mono.empty();
+                                }
+                            }).subscribe();
+                    return Mono.never();
+                })
+                .subscribe();
+
+        return Mono.never();
+    }
+}

--- a/src/main/java/kutaverse/game/websocket/chat/dto/request/ChatRequestDto.java
+++ b/src/main/java/kutaverse/game/websocket/chat/dto/request/ChatRequestDto.java
@@ -1,0 +1,15 @@
+package kutaverse.game.websocket.chat.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Setter
+@Getter
+@ToString
+public class ChatRequestDto {
+
+    private String userId;
+    private String content;
+
+}

--- a/src/main/java/kutaverse/game/websocket/chat/dto/response/ChatResponseDto.java
+++ b/src/main/java/kutaverse/game/websocket/chat/dto/response/ChatResponseDto.java
@@ -1,0 +1,15 @@
+package kutaverse.game.websocket.chat.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
+public class ChatResponseDto {
+
+    private String userId;
+    private String content;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,10 @@ spring:
     url: r2dbc:pool:mysql://localhost:3306/webflux
     username: root
     password: ${MYSQL_PASSWORD}
-    initialization-mode: always
+    #initialization-mode: always
+  data:
+    mongodb:
+        uri: ${MONGO_URL}
 
 ---
 

--- a/src/test/java/kutaverse/game/map/integration/UserRepositoryTest.java
+++ b/src/test/java/kutaverse/game/map/integration/UserRepositoryTest.java
@@ -2,7 +2,6 @@ package kutaverse.game.map.integration;
 
 import kutaverse.game.map.domain.Status;
 import kutaverse.game.map.domain.User;
-import kutaverse.game.map.repository.MysqlUserRepository;
 import kutaverse.game.map.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,7 +9,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -31,12 +29,12 @@ public class UserRepositoryTest {
     @DisplayName("user를 데이터베이스에 저장한다.")
     public void test1(){
         //given
-        userRepository.save(user).block();
+        User saveUser = userRepository.save(user).block();
         //when
-        Mono<User> findMonoUser = userRepository.get(user.getUserId());
+        Mono<User> findMonoUser = userRepository.getByUserId(saveUser.getUserId());
         //then
         StepVerifier.create(findMonoUser)
-                .expectNext(user)
+                .expectNext(saveUser)
                 .verifyComplete();
         //왜 localDateTime 문제가 생기지?
     }


### PR DESCRIPTION
### ✏️ 작업 개요
채팅 기능 추가
맵 이동 관련 db 수정
### ⛳ 작업 분류
- [x] 채팅 기능
- [x] 맵 이동 관련 db 수정
- [x] ci,cd test 수정  

### 🔨 작업 상세 내용
  1. 아주 단순한 채팅 기능을 구현
  2. 맵 이동 관련하여 PK 값은 auto increment 값으로 추가하였습니다. 이제 유저ID는 컬럼이 됩니다.
  3. 몽고 atlas 설정(테스트환경, 배포 환경)

### 💡 생각해볼 문제
- 개발하면서 느낀 건데 만약 PK값이 유일성 최소성을 보장하는 상황에서도 사용자의 입력으로 PK를 정한다는 것이 위험하게 느껴 auto increment 값을 추가하였습니다.
- 몽고 atlas 을 연결함에 따라 로컬 환경에서 작업시 몇까지 문제가 발생할 것으로 보입니다.(같은 db를 공유하고 있기 때문에) 일단 배포환경은 database를 분리하였습니다.
- 테스트하면서 webflux 환경에서는 @transactional을 지원하지 않는 이슈로 인해 문제가 있습니다. 가장 큰 문제는 롤백이 되지 않기 때문에 의도하지 않은 환경에서 테스트가 영향을 주고 있습니다.
- 롤백을 위한 Transaction 클래스를 구현하는 글을 보았는데 제한적인 상황에서 사용가능합니다. 
- 
