### PR TITLE
멀티게임 종료후 재 매칭시 버그 발생

### DIFF
--- a/src/main/java/kutaverse/game/websocket/taggame/util/TagGameRoom.java
+++ b/src/main/java/kutaverse/game/websocket/taggame/util/TagGameRoom.java
@@ -16,4 +16,10 @@ public class TagGameRoom {
         this.players = players;
     }
 
+    public void delete(){
+        for (Map.Entry<String, WebSocketSession> player : players) {
+            player.getValue().close().subscribe();
+        }
+    }
+
 }

--- a/src/main/java/kutaverse/game/websocket/taggame/util/TagGameRoomManager.java
+++ b/src/main/java/kutaverse/game/websocket/taggame/util/TagGameRoomManager.java
@@ -16,7 +16,10 @@ public class TagGameRoomManager {
     public static TagGameRoom getGameRoom(String roomId) { return gameRooms.get(roomId); }
 
     public static void deleteGameRoom(String roomId) {
-        gameRooms.remove(roomId); }
+        TagGameRoom tagGameRoom = gameRooms.get(roomId);
+        tagGameRoom.delete();
+        gameRooms.remove(roomId);
+    }
 
 
 }


### PR DESCRIPTION
### ✏️ 작업 개요
- 멀티게임 종료후 재 매칭시 버그 발생

### ⛳ 작업 분류
- [x] 버그 수정

### 🔨 작업 상세 내용
  1. 멀티게임 종료후 websocket 커넥션을 끊도록 변경
  2. 내부 중복 검사 큐 세션 open 확인 추가


### 💡 생각해볼 문제
- 원래는 멀티게임이 종료되더라도 다시 매칭을 보내면 재매칭 할 수 있도록 구현하였는데, 고려할게 좀 있어서 게임이 끝나면 연결을 서버에서 끊도록 변경하였습니다.
