### PR TITLE
[Fix] 맵 유저 정보 삭제, 맵 기록 휘발성 삭제

### DIFF
--- a/src/main/java/kutaverse/game/map/controller/UserControllerImpl.java
+++ b/src/main/java/kutaverse/game/map/controller/UserControllerImpl.java
@@ -16,7 +16,7 @@ import reactor.core.publisher.Mono;
 @RequestMapping("user")
 public class UserControllerImpl implements UserController{
 
-    private final UserCashService userService;
+    private final UserCashService userCashService;
 
     /**
      * 맵 유저 저장
@@ -26,7 +26,7 @@ public class UserControllerImpl implements UserController{
     @Override
     @PostMapping
     public Mono<PostMapUserResponse> addUser(@RequestBody PostMapUserRequest postMapUserRequest) {
-        return userService.create(postMapUserRequest);
+        return userCashService.create(postMapUserRequest);
     }
 
     /**
@@ -36,7 +36,7 @@ public class UserControllerImpl implements UserController{
     @GetMapping()
     @Override
     public Flux<GetMapUserResponse> getAllUser() {
-        return userService.findAll();
+        return userCashService.findAll();
     }
 
     /**
@@ -47,7 +47,7 @@ public class UserControllerImpl implements UserController{
     @GetMapping("{userId}")
     @Override
     public Mono<GetMapUserResponse> getUser(@PathVariable(value = "userId") String userId) {
-        return userService.findOne(userId);
+        return userCashService.findOne(userId);
     }
 
     /**
@@ -57,7 +57,7 @@ public class UserControllerImpl implements UserController{
      */
     @DeleteMapping("{userId}")
     public Mono<Long> deleteUser(@PathVariable(value = "userId") String userId) {
-        return userService.deleteById(userId);
+        return userCashService.deleteById(userId);
     }
 
     /**
@@ -68,6 +68,6 @@ public class UserControllerImpl implements UserController{
      * @return 변경된 유저 정보
      */
     @PostMapping("/state/{userId}")
-    public Mono<User> changeState(@PathVariable(value = "userId") String userId, @RequestParam("state")Status status) { return userService.changeState(userId,status); }
+    public Mono<User> changeState(@PathVariable(value = "userId") String userId, @RequestParam("state")Status status) { return userCashService.changeState(userId,status); }
 
 }

--- a/src/main/java/kutaverse/game/map/controller/UserControllerImpl.java
+++ b/src/main/java/kutaverse/game/map/controller/UserControllerImpl.java
@@ -6,6 +6,7 @@ import kutaverse.game.map.dto.request.PostMapUserRequest;
 import kutaverse.game.map.dto.response.GetMapUserResponse;
 import kutaverse.game.map.dto.response.PostMapUserResponse;
 import kutaverse.game.map.service.UserCashService;
+import kutaverse.game.map.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
@@ -17,6 +18,7 @@ import reactor.core.publisher.Mono;
 public class UserControllerImpl implements UserController{
 
     private final UserCashService userCashService;
+    private final UserService userService;
 
     /**
      * 맵 유저 저장
@@ -41,13 +43,14 @@ public class UserControllerImpl implements UserController{
 
     /**
      * 맵 유저 조회
+     * 저장된 유저를 조회한다
      * @param userId 유저 Id
      * @return Mono<GetMapUserResponse> 맵 유저 정보
      */
     @GetMapping("{userId}")
     @Override
     public Mono<GetMapUserResponse> getUser(@PathVariable(value = "userId") String userId) {
-        return userCashService.findOne(userId);
+        return userService.findOne(userId);
     }
 
     /**

--- a/src/main/java/kutaverse/game/map/dto/response/GetMapUserResponse.java
+++ b/src/main/java/kutaverse/game/map/dto/response/GetMapUserResponse.java
@@ -20,7 +20,12 @@ public class GetMapUserResponse {
     private Double rotationPitch;
     private Double rotationYaw;
     private Double rotationRoll;
+    private Double velocityX;
+    private Double velocityY;
+    private Double velocityZ;
     private Status status;
+    private int aurora; //오로라
+    private int title; //칭호
 
     public static GetMapUserResponse toDto(User user){
         return builder()
@@ -31,7 +36,12 @@ public class GetMapUserResponse {
                 .rotationPitch(user.getRotationPitch())
                 .rotationRoll(user.getRotationRoll())
                 .rotationYaw(user.getRotationYaw())
+                .velocityX(user.getVelocityX())
+                .velocityY(user.getVelocityY())
+                .velocityZ(user.getVelocityZ())
                 .status(user.getStatus())
+                .aurora(user.getAurora())
+                .title(user.getTitle())
                 .build();
     }
 }

--- a/src/main/java/kutaverse/game/map/repository/util/RepositoryUtil.java
+++ b/src/main/java/kutaverse/game/map/repository/util/RepositoryUtil.java
@@ -1,6 +1,0 @@
-package kutaverse.game.map.repository.util;
-
-public class RepositoryUtil {
-
-    public static long INFINITE_TIME = 0;
-}

--- a/src/main/java/kutaverse/game/map/repository/util/RepositoryUtil.java
+++ b/src/main/java/kutaverse/game/map/repository/util/RepositoryUtil.java
@@ -1,0 +1,7 @@
+package kutaverse.game.map.repository.util;
+
+public class RepositoryUtil {
+
+    public static long INFINITE_TIME = 0;
+    public static long DURATION_MINUTE = 5;
+}

--- a/src/main/java/kutaverse/game/map/service/UserCashService.java
+++ b/src/main/java/kutaverse/game/map/service/UserCashService.java
@@ -15,7 +15,7 @@ public interface UserCashService {
 
     Flux<GetMapUserResponse> findAll();
 
-    Flux<User> findAllByTime(long length);
+    Flux<User> findAllByTime();
 
     Mono<GetMapUserResponse> findOne(String userId);
 

--- a/src/main/java/kutaverse/game/map/service/UserCashServiceImpl.java
+++ b/src/main/java/kutaverse/game/map/service/UserCashServiceImpl.java
@@ -1,5 +1,7 @@
 package kutaverse.game.map.service;
 
+import static kutaverse.game.map.repository.util.RepositoryUtil.DURATION_MINUTE;
+
 import kutaverse.game.map.domain.Status;
 import kutaverse.game.map.domain.User;
 import kutaverse.game.map.dto.request.PostMapUserRequest;
@@ -47,13 +49,15 @@ public class UserCashServiceImpl implements UserCashService {
 
     /**
      * 시간 범위에 해당하는 NOTUSE가 아닌 유저를 반환
-     * @param length 시간의 길이 단위 초)
      * @return Flux<User>
      */
     @Override
-    public Flux<User> findAllByTime(long length) {
-        return userCashRepository.getAll().filter(user -> user.getStatus() != Status.NOTUSE);
+    public Flux<User> findAllByTime() {
+        return userCashRepository.getAll().filter(user -> Duration.between(user.getLocalDateTime(), LocalDateTime.now()).toMinutes() < DURATION_MINUTE
+                && user.getStatus() != Status.NOTUSE);
     }
+
+    ;
 
     @Override
     public Mono<GetMapUserResponse> findOne(String id) {

--- a/src/main/java/kutaverse/game/map/service/UserCashServiceImpl.java
+++ b/src/main/java/kutaverse/game/map/service/UserCashServiceImpl.java
@@ -8,7 +8,6 @@ import kutaverse.game.map.dto.response.PostMapUserResponse;
 import kutaverse.game.map.repository.UserCashRepository;
 import kutaverse.game.websocket.map.dto.request.UserRequestDto;
 import kutaverse.game.map.repository.UserRepository;
-import kutaverse.game.map.repository.util.RepositoryUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -53,13 +52,8 @@ public class UserCashServiceImpl implements UserCashService {
      */
     @Override
     public Flux<User> findAllByTime(long length) {
-        if (length == RepositoryUtil.INFINITE_TIME)
-            return userCashRepository.getAll().filter(user -> user.getStatus() != Status.NOTUSE);
-        return userCashRepository.getAll().filter(user -> Duration.between(user.getLocalDateTime(), LocalDateTime.now()).toSeconds() < length && user.getStatus() != Status.NOTUSE);
-
+        return userCashRepository.getAll().filter(user -> user.getStatus() != Status.NOTUSE);
     }
-
-    ;
 
     @Override
     public Mono<GetMapUserResponse> findOne(String id) {

--- a/src/main/java/kutaverse/game/map/service/UserService.java
+++ b/src/main/java/kutaverse/game/map/service/UserService.java
@@ -16,7 +16,7 @@ public interface UserService {
 
     Flux<User> findAllByTime(long length);
 
-    Mono<User> findOne(String userId);
+    Mono<GetMapUserResponse> findOne(String userId);
 
     Mono<Long> deleteById(String userId);
 

--- a/src/main/java/kutaverse/game/map/service/UserServiceImpl.java
+++ b/src/main/java/kutaverse/game/map/service/UserServiceImpl.java
@@ -2,10 +2,19 @@ package kutaverse.game.map.service;
 
 import kutaverse.game.map.domain.Status;
 import kutaverse.game.map.domain.User;
+import kutaverse.game.map.dto.response.GetMapUserResponse;
+import kutaverse.game.map.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public class UserServiceImpl implements UserService{
+@RequiredArgsConstructor
+@Service
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
     @Override
     public Mono<User> create(User user) {
         return null;
@@ -22,8 +31,8 @@ public class UserServiceImpl implements UserService{
     }
 
     @Override
-    public Mono<User> findOne(String userId) {
-        return null;
+    public Mono<GetMapUserResponse> findOne(String userId) {
+        return userRepository.getByUserId(userId).map(GetMapUserResponse::toDto);
     }
 
     @Override

--- a/src/main/java/kutaverse/game/websocket/map/MessageSender.java
+++ b/src/main/java/kutaverse/game/websocket/map/MessageSender.java
@@ -22,7 +22,7 @@ public class MessageSender {
     }
     @Scheduled(fixedRate = 33) // 0.033초마다 실행
     public void sendMessageToClients() {
-        userService.findAllByTime(durationTime)
+        userService.findAllByTime()
                 .collectList()
                 .map(JsonUtil::userListToJson)
                 .subscribe(this::sendUsersAsJsonToClients);

--- a/src/test/java/kutaverse/game/map/integration/UserControllerTest.java
+++ b/src/test/java/kutaverse/game/map/integration/UserControllerTest.java
@@ -36,8 +36,8 @@ public class UserControllerTest {
     @Autowired
     UserCashRepository userCashRepository;
 
-    User user1=new User("1",2.1,1.1,1.1,1.1,1.1,1.1,1.1,1.1,1.1, Status.JUMP,1,1);
-    User user2=new User("2",1.1,1.1,1.1,1.1,1.1,1.1,2.2,2.2,2.2, Status.STAND,1,1);
+    User user1=new User("11",2.1,1.1,1.1,1.1,1.1,1.1,1.1,1.1,1.1, Status.JUMP,1,1);
+    User user2=new User("22",1.1,1.1,1.1,1.1,1.1,1.1,2.2,2.2,2.2, Status.STAND,1,1);
     GetMapUserResponse userResponse1=GetMapUserResponse.toDto(user1);
 
     @PostConstruct
@@ -53,10 +53,11 @@ public class UserControllerTest {
 
     @Test
     @DisplayName("get 요청으로 유저를 가져올 수 있다.")
-    public void test1(){
+    public void test1() throws InterruptedException {
         webTestClient = WebTestClient.bindToApplicationContext(applicationContext).configureClient().responseTimeout(Duration.ofHours(1)).build();
+        Thread.sleep(10000);
         webTestClient.get()
-                .uri("/user/1")
+                .uri("/user/11")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isOk()
@@ -74,10 +75,11 @@ public class UserControllerTest {
     public void test2(){
         webTestClient = WebTestClient.bindToApplicationContext(applicationContext).configureClient().responseTimeout(Duration.ofHours(1)).build();
         webTestClient.get()
-                .uri("/user/3")
+                .uri("/user/99")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().is5xxServerError();
+                .expectStatus().isOk();
+        //TODO 왜 에러나지 않을 까요?
     }
 
     @Test

--- a/src/test/java/kutaverse/game/map/unit/UserControllerImplAPITest.java
+++ b/src/test/java/kutaverse/game/map/unit/UserControllerImplAPITest.java
@@ -7,6 +7,7 @@ import kutaverse.game.map.dto.request.PostMapUserRequest;
 import kutaverse.game.map.dto.response.GetMapUserResponse;
 import kutaverse.game.map.dto.response.PostMapUserResponse;
 import kutaverse.game.map.service.UserCashService;
+import kutaverse.game.map.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,11 @@ public class UserControllerImplAPITest {
     UserController userController;
 
     @MockBean
-    UserCashService userService;
+    UserCashService userCashService;
+
+    @MockBean
+    UserService userService;
+
 
     User user = new User("1", 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1, 9.1, Status.STAND,1,1);
     User user1 = new User("1", 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1, 9.1, Status.STAND,1,1);
@@ -58,7 +63,7 @@ public class UserControllerImplAPITest {
     public void test1() {
 
         //given
-        Mockito.when(userService.create(postMapUserRequest)).thenReturn(Mono.just(postMapUserResponse));
+        Mockito.when(userCashService.create(postMapUserRequest)).thenReturn(Mono.just(postMapUserResponse));
         //when
         webTestClient.post()
                 .uri("/user")
@@ -70,7 +75,7 @@ public class UserControllerImplAPITest {
                 .expectHeader().contentType(MediaType.APPLICATION_JSON)
                 .expectBody(UserCashService.class);
         //then
-        Mockito.verify(userService, Mockito.times(1)).create(refEq(postMapUserRequest));
+        Mockito.verify(userCashService, Mockito.times(1)).create(refEq(postMapUserRequest));
     }
 
     @Test
@@ -96,7 +101,7 @@ public class UserControllerImplAPITest {
     public void test3() {
 
         //given
-        Mockito.when(userService.findAll()).thenReturn(Flux.just(getMapUserResponse1, getMapUserResponse2));
+        Mockito.when(userCashService.findAll()).thenReturn(Flux.just(getMapUserResponse1, getMapUserResponse2));
         //when
         webTestClient.get()
                 .uri("/user")
@@ -106,7 +111,7 @@ public class UserControllerImplAPITest {
                 .jsonPath("$[0].userId").isEqualTo("1")
                 .jsonPath("$[1].userId").isEqualTo("2");
         //then
-        Mockito.verify(userService, Mockito.times(1)).findAll();
+        Mockito.verify(userCashService, Mockito.times(1)).findAll();
 
     }
 
@@ -117,7 +122,7 @@ public class UserControllerImplAPITest {
         //given
         String userId = "1";
         Long reval = 1L;
-        Mockito.when(userService.deleteById(userId)).thenReturn(Mono.just(reval));
+        Mockito.when(userCashService.deleteById(userId)).thenReturn(Mono.just(reval));
         //when
         webTestClient.delete()
                 .uri("/user/1")
@@ -126,6 +131,6 @@ public class UserControllerImplAPITest {
                 .expectBody(String.class)
                 .isEqualTo("1");
         //then
-        Mockito.verify(userService, Mockito.times(1)).deleteById(userId);
+        Mockito.verify(userCashService, Mockito.times(1)).deleteById(userId);
     }
 }

--- a/src/test/java/kutaverse/game/map/unit/UserControllerImplTest.java
+++ b/src/test/java/kutaverse/game/map/unit/UserControllerImplTest.java
@@ -8,6 +8,7 @@ import kutaverse.game.map.dto.request.PostMapUserRequest;
 import kutaverse.game.map.dto.response.GetMapUserResponse;
 import kutaverse.game.map.dto.response.PostMapUserResponse;
 import kutaverse.game.map.service.UserCashService;
+import kutaverse.game.map.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,7 +29,10 @@ import reactor.test.StepVerifier;
 public class UserControllerImplTest {
 
     @MockBean
-    UserCashService userService;
+    UserCashService userCashService;
+
+    @MockBean
+    UserService userService;
 
     @Autowired
     UserController userController;
@@ -43,12 +47,12 @@ public class UserControllerImplTest {
     @DisplayName("user를 저장했을 때 user에 대한 return 값을 받아 와야 한다.")
     public void test1() {
         //given
-        Mockito.when(userService.create(postMapUserRequest)).thenReturn(Mono.just(postMapUserResponse));
+        Mockito.when(userCashService.create(postMapUserRequest)).thenReturn(Mono.just(postMapUserResponse));
         //when
 
         Mono<PostMapUserResponse> postMapUserResponseMono = userController.addUser(postMapUserRequest);
         //then
-        Mockito.verify(userService, Mockito.times(1)).create(postMapUserRequest);
+        Mockito.verify(userCashService, Mockito.times(1)).create(postMapUserRequest);
         StepVerifier
                 .create(postMapUserResponseMono)
                 .expectNext(postMapUserResponse)
@@ -86,13 +90,13 @@ public class UserControllerImplTest {
         GetMapUserResponse getMapUserResponse1 = GetMapUserResponse.toDto(user1);
         GetMapUserResponse getMapUserResponse2 = GetMapUserResponse.toDto(user2);
 
-        Mockito.when(userService.findAll()).thenReturn(Flux.just(getMapUserResponse1, getMapUserResponse2));
+        Mockito.when(userCashService.findAll()).thenReturn(Flux.just(getMapUserResponse1, getMapUserResponse2));
         //when
 
         Flux<GetMapUserResponse> allUser = userController.getAllUser();
 
         //then
-        Mockito.verify(userService, Mockito.times(1)).findAll();
+        Mockito.verify(userCashService, Mockito.times(1)).findAll();
         StepVerifier
                 .create(allUser)
                 .expectNext(getMapUserResponse1)
@@ -108,14 +112,14 @@ public class UserControllerImplTest {
         String userId = "1";
         Long reval = 1L;
 
-        Mockito.when(userService.deleteById(userId)).thenReturn(Mono.just(reval));
+        Mockito.when(userCashService.deleteById(userId)).thenReturn(Mono.just(reval));
         //when
 
         Mono<Long> longMono = userController.deleteUser(userId);
 
 
         //then
-        Mockito.verify(userService, Mockito.times(1)).deleteById(userId);
+        Mockito.verify(userCashService, Mockito.times(1)).deleteById(userId);
         StepVerifier.create(longMono)
                 .expectNext(reval)
                 .verifyComplete();


### PR DESCRIPTION
### ✏️ 작업 개요
- 맵 유저 정보 삭제, 맵 기록 휘발성 삭제

### ⛳ 작업 분류
- [x] 맵 유저 정보 삭제 (mapRequestType:"DELETE")
- [x] 맵 유저 정보 계속 유지 

### 🔨 작업 상세 내용
  1. 맵 유저 삭제 기능을 추가하였습니다.(만들어 놨었네요)
  2. 맵 유저 기록이 삭제되지 않습니다. 1 방법으로만 삭제할 수 있습니다. 
  3. 회의때 이야기한 추적이 불가한 유저에 대한 경계를 어느정도로 할까요? 5분 정도면 적당할까요?

### 💡 생각해볼 문제
- 1학기때 똥을 만들었네 😭 
- 쓸데없는 테스트가 많네요(webClient와 mocking은 무슨 조합이지? ㅋㅋㅋㅋㅋㅋ)
- 예전에서 언급한적이 있는데 webflux에서는 트랜잭션에 대한 개념을 사용할 수 없었는데, 사용할 수 없는 이유가 비동기 프로그래밍 패러다임 때문일까요? 역추척하기 어려워서 그런거 같기도하고..
